### PR TITLE
fix: 修复提示文本,优化getEmptyOrDefault方法

### DIFF
--- a/app/src/main/java/com/hi/dhl/pokemon/data/repository/PokemonRemoteMediator.kt
+++ b/app/src/main/java/com/hi/dhl/pokemon/data/repository/PokemonRemoteMediator.kt
@@ -58,7 +58,7 @@ class PokemonRemoteMediator(
              *      LoadType.PREPEND
              *      LoadType.APPEND
              *
-             * 2. 请问网络数据
+             * 2. 访问网络数据
              *
              * 3. 将网路插入到本地数据库中
              */

--- a/app/src/main/java/com/hi/dhl/pokemon/ext/ContextExt.kt
+++ b/app/src/main/java/com/hi/dhl/pokemon/ext/ContextExt.kt
@@ -37,10 +37,10 @@ fun Context.isConnectedNetwork(): Boolean = run {
     activeNetwork?.isConnectedOrConnecting == true
 }
 
-inline fun <T> String.getEmptyOrDefault(default: () -> T): T {
-    if (isNullOrEmpty() || this == "null") {
-        return default()
+inline fun <reified T> String.getEmptyOrDefault(default: () -> T): T {
+    return if (isNullOrEmpty() || this == "null") {
+        default()
     } else {
-        return this as T
+        this as T
     }
 }


### PR DESCRIPTION
修复PokemonRemoteMediator提示文本,优化ContextExt->getEmptyOrDefault方法